### PR TITLE
add IsDecl, refactor IsExpr and IsStmt

### DIFF
--- a/decl.go
+++ b/decl.go
@@ -2,6 +2,12 @@ package astp
 
 import "go/ast"
 
+// IsDecl reports whether node is a ast.Decl.
+func IsDecl(node ast.Node) bool {
+	_, ok := node.(ast.Decl)
+	return ok
+}
+
 // IsFuncDecl returns true if a given ast.Node is a function declaration (*ast.FuncDecl).
 func IsFuncDecl(node ast.Node) bool {
 	_, ok := node.(*ast.FuncDecl)

--- a/expr.go
+++ b/expr.go
@@ -4,28 +4,8 @@ import "go/ast"
 
 // IsExpr returns true if a given ast.Node is an expression(ast.Expr).
 func IsExpr(node ast.Node) bool {
-	return IsBadExpr(node) ||
-		IsIdent(node) ||
-		IsEllipsis(node) ||
-		IsBasicLit(node) ||
-		IsFuncLit(node) ||
-		IsCompositeLit(node) ||
-		IsParenExpr(node) ||
-		IsSelectorExpr(node) ||
-		IsIndexExpr(node) ||
-		IsSliceExpr(node) ||
-		IsTypeAssertExpr(node) ||
-		IsCallExpr(node) ||
-		IsStarExpr(node) ||
-		IsUnaryExpr(node) ||
-		IsBinaryExpr(node) ||
-		IsKeyValueExpr(node) ||
-		IsArrayType(node) ||
-		IsStructType(node) ||
-		IsFuncType(node) ||
-		IsInterfaceType(node) ||
-		IsMapType(node) ||
-		IsChanType(node)
+	_, ok := node.(ast.Expr)
+	return ok
 }
 
 // IsBadExpr returns true if a given ast.Node is a bad expression (*ast.IsBadExpr).

--- a/stmt.go
+++ b/stmt.go
@@ -4,27 +4,8 @@ import "go/ast"
 
 // IsStmt returns true if a given ast.Node is a statement(ast.Stmt).
 func IsStmt(node ast.Node) bool {
-	return IsBadStmt(node) ||
-		IsDeclStmt(node) ||
-		IsEmptyStmt(node) ||
-		IsLabeledStmt(node) ||
-		IsExprStmt(node) ||
-		IsSendStmt(node) ||
-		IsIncDecStmt(node) ||
-		IsAssignStmt(node) ||
-		IsGoStmt(node) ||
-		IsDeferStmt(node) ||
-		IsReturnStmt(node) ||
-		IsBranchStmt(node) ||
-		IsBlockStmt(node) ||
-		IsIfStmt(node) ||
-		IsCaseClause(node) ||
-		IsSwitchStmt(node) ||
-		IsTypeSwitchStmt(node) ||
-		IsCommClause(node) ||
-		IsSelectStmt(node) ||
-		IsForStmt(node) ||
-		IsRangeStmt(node)
+	_, ok := node.(ast.Stmt)
+	return ok
 }
 
 // IsBadStmt returns true if a given ast.Node is a XXX(*ast.BadStmt)


### PR DESCRIPTION
New function `IsDecl` has more idiomatic "predicate" comment.

As Bradfitz once said:
> Go style for boolean methods is to say "reports whether" instead of "returns true if".

[source](https://go-review.googlesource.com/c/arch/+/104475/2/x86/x86csv/x86csv.go#78)